### PR TITLE
Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # solver-specific files that might be generated while running tests locally
 gurobi.log
+
+# Virtual environment
+myenv

--- a/CONTRIBUTION_GUIDE.rst
+++ b/CONTRIBUTION_GUIDE.rst
@@ -7,7 +7,7 @@ Installation
 
 Create a fork of the `development` branch and clone to your computer. We recommend working within a virtualenv, and installing your clone locally by navigating to the root of the project (e.g. /Medusa/) and running::
 
-    python setup.py development
+    python setup.py develop
 
 You may need to rerun this command after making changes to medusa for those changes to take effect.
 

--- a/medusa/flux_analysis/flux_balance.py
+++ b/medusa/flux_analysis/flux_balance.py
@@ -12,11 +12,14 @@ from cobra import Reaction
 
 from medusa.core.member import Member
 
-
 def _optimize_ensemble(ensemble, return_flux, member_id, **kwargs):
+
     ensemble.set_state(member_id)
     ensemble.base_model.optimize(**kwargs)
-    flux_dict = {rxn:ensemble.base_model.reactions.get_by_id(rxn).flux
+
+    # TODO solved the error, but revise!
+    reaction_ids = [rxn.id for rxn in ensemble.base_model.reactions]
+    flux_dict = {rxn:ensemble.base_model.reactions[reaction_ids.index(rxn)].flux
                         for rxn in return_flux}
     return (member_id, flux_dict, ensemble.base_model.solver.status)
 

--- a/medusa/flux_analysis/variability.py
+++ b/medusa/flux_analysis/variability.py
@@ -1,4 +1,4 @@
-from pandas import DataFrame
+import pandas as pd
 from random import sample
 from cobra.flux_analysis.variability import (
     flux_variability_analysis, find_blocked_reactions,
@@ -60,7 +60,7 @@ def ensemble_fva(ensemble, reaction_list, num_models=[],specific_models=None,
 
     # initialize dataframe to store results. max and min for each model will
     # each take a single row, and the columns will be reactions.
-    all_fva_results = DataFrame()
+    all_fva_results = pd.DataFrame()
 
     if specific_models:
         model_list = specific_models
@@ -79,5 +79,5 @@ def ensemble_fva(ensemble, reaction_list, num_models=[],specific_models=None,
             fva_result = fva_result.T
             # add the model source as a column
             fva_result['model_source'] = [model,model]
-            all_fva_results = all_fva_results.append(fva_result)
+            all_fva_results = pd.concat([all_fva_results, fva_result])
     return all_fva_results

--- a/medusa/reconstruct/load_from_file.py
+++ b/medusa/reconstruct/load_from_file.py
@@ -1,6 +1,6 @@
 import medusa
 import cobra
-import cobra.test
+import cobra.io
 import math
 import copy
 import random

--- a/medusa/test/__init__.py
+++ b/medusa/test/__init__.py
@@ -4,7 +4,7 @@ import cobra
 import json
 import pandas as pd
 
-import cobra.test
+import cobra.io
 from cobra.core import Reaction
 
 from medusa.core.ensemble import Ensemble
@@ -33,14 +33,14 @@ def create_test_ensemble(ensemble_name="Staphylococcus aureus"):
 def create_test_model(model_name="textbook"):
     """Returns a cobra.Model for testing
     model_name: str
-        One of ['Staphylococcus aureus'] or any models in cobra.test
+        One of ['Staphylococcus aureus'] or any models in cobra.io
     """
     if model_name == "Saureus_seed":
         base_model = cobra.io.load_json_model(join(data_dir, 'Staphylococcus aureus.json'))
 
     else:
         try:
-            base_model = cobra.test.create_test_model(model_name)
+            base_model = cobra.io.load_model(model_name)
         except:
             raise ValueError('model_name does not match one of the test models available')
 

--- a/medusa/test/test_ensemble.py
+++ b/medusa/test/test_ensemble.py
@@ -1,4 +1,4 @@
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 
 from pickle import load
@@ -10,10 +10,10 @@ MISSING_ATTRIBUTE_DEFAULT = {'lower_bound':0,'upper_bound':0}
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2],
@@ -22,13 +22,13 @@ def construct_textbook_ensemble():
 
 def construct_mixed_ensemble():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model4 = model3.copy()
@@ -43,7 +43,7 @@ def test_ensemble_creation():
     test_ensemble = construct_textbook_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 
@@ -72,7 +72,7 @@ def test_mixed_ensemble_creation():
     test_ensemble = construct_mixed_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 
@@ -97,7 +97,7 @@ def test_mixed_ensemble_creation():
 
 def test_extract_member():
     test_ensemble = construct_textbook_ensemble()
-    original_model = create_test_model("textbook")
+    original_model = load_model("textbook")
 
     extracted_member = test_ensemble.extract_member(test_ensemble.members[0])
 
@@ -145,7 +145,7 @@ def test_pickle():
         unpickled = load(infile)
 
     test_ensemble = unpickled
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 

--- a/medusa/test/test_ensemble.py
+++ b/medusa/test/test_ensemble.py
@@ -163,7 +163,8 @@ def test_pickle():
     # each feature should have a component_attribute in the list of allowable
     # attributes
     # each feature should have at least two unique state values across all models
+    reaction_ids = {rxn.id for rxn in test_ensemble.base_model.reactions}
     for feature in test_ensemble.features:
-        assert feature.base_component in test_ensemble.base_model.reactions
+        assert feature.base_component.id in reaction_ids
         assert feature.component_attribute in REACTION_ATTRIBUTES
         assert len(set(feature.states.values())) > 1

--- a/medusa/test/test_flux_balance.py
+++ b/medusa/test/test_flux_balance.py
@@ -86,5 +86,5 @@ def test_fba_specific_models():
         assert rows == len(model_list)
         assert columns == len(ensemble.base_model.reactions)
 
-        assert rownames.contains(model1.id)
-        assert rownames.contains(model2.id)
+        assert model1.id in rownames
+        assert model2.id in rownames

--- a/medusa/test/test_flux_balance.py
+++ b/medusa/test/test_flux_balance.py
@@ -1,15 +1,15 @@
 
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.flux_analysis.flux_balance import optimize_ensemble
 
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2],
@@ -18,13 +18,13 @@ def construct_textbook_ensemble():
 
 def construct_mixed_ensemble():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model4 = model3.copy()

--- a/medusa/test/test_load_from_file.py
+++ b/medusa/test/test_load_from_file.py
@@ -1,5 +1,5 @@
 import cobra
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.reconstruct.load_from_file import batch_load_from_files
 
@@ -8,15 +8,15 @@ MISSING_ATTRIBUTE_DEFAULT = {'lower_bound':0,'upper_bound':0}
 
 def construct_mixed_ensemble_2():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
     cobra.io.save_json_model(model1, "model1.json")
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     cobra.io.save_json_model(model2, "model2.json")
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model3.reactions.get_by_id('SUCCt2_2').lower_bound = -1000
@@ -34,15 +34,15 @@ def construct_mixed_batch_ensemble():
     # UPDATE PATHS TO SAVE AND LOAD MODELS
     
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
     cobra.io.save_json_model(model1, "model1.json")
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     cobra.io.save_json_model(model2, "model2.json")
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model3.reactions.get_by_id('SUCCt2_2').lower_bound = -1000
@@ -63,7 +63,7 @@ def test_batch_load_vs_innate():
     test_batch_ensemble = construct_mixed_batch_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
     assert len(test_batch_ensemble.base_model.reactions) == len(textbook.reactions)

--- a/medusa/test/test_reconstruct.py
+++ b/medusa/test/test_reconstruct.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from cobra.test import create_test_model
+from cobra.io import load_model
 from cobra.io import load_json_model
 from cobra.core import Reaction
 

--- a/medusa/test/test_variability.py
+++ b/medusa/test/test_variability.py
@@ -1,17 +1,17 @@
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.flux_analysis.variability import ensemble_fva
 
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[2:5])
     model3.id = 'third_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2,model3],


### PR DESCRIPTION
A few functions in the current Medusa/development branch are outdated, or now use different conventions. This affects the package performance, e.g., the first tutorial currently doesn't run, and running the pytests is also not possible. Merging this maintenance branch resolves this by:

- replace `from cobra.test import create_test_model` with `from cobra.io import load_model` everywhere
- replace `python setup.py development` with `python setup.py develop`
- replace `pd.append` with `pd.concat`
- replace `rownames.contains` with `in rownames`
- In two scripts (test_ensemble.py and flux_balance.py), a small workaround was introduced. Originally, reactions objects were matched directly between the ensemble.base_model and the textbook model. This sometimes leads to issues (we can discuss), which are circumvented by searching on reaction.id.
