### PR TITLE
Fast bounds feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # solver-specific files that might be generated while running tests locally
 gurobi.log
+
+# Virtual environment
+myenv

--- a/CONTRIBUTION_GUIDE.rst
+++ b/CONTRIBUTION_GUIDE.rst
@@ -7,7 +7,7 @@ Installation
 
 Create a fork of the `development` branch and clone to your computer. We recommend working within a virtualenv, and installing your clone locally by navigating to the root of the project (e.g. /Medusa/) and running::
 
-    python setup.py development
+    python setup.py develop
 
 You may need to rerun this command after making changes to medusa for those changes to take effect.
 

--- a/medusa/boundsEnsemble.py
+++ b/medusa/boundsEnsemble.py
@@ -11,7 +11,7 @@ REACTION_ATTRIBUTES = ['lower_bound', 'upper_bound']
 
 def boundsEnsemble(model, boundsDict):
     '''
-    Create an ensemble of models where each member has the same reactions but
+    Create an ensemble of models where all members have the same reactions but
     different reaction bounds, without the need of first constructing a list of these
     individual models. While all members share the same reactions, the bounds of some
     reactions in some members maybe set to (0,0), i.e., inactivating the reaction.
@@ -19,11 +19,11 @@ def boundsEnsemble(model, boundsDict):
     Parameters
     ----------
     model : cobra.Model
-        The ensemble with which to perform reaction deletions
+        A cobrapy model.
     boundsDict : A dictionary of pandas.DataFrames
-        A dictionary of dataframes in which each row (index) represents a 
-        model within the ensemble, and each column represents a reaction for 
-        which values of objective when the reaction is deleted are returned.
+        A dictionary with reaction identifiers as keys and dataframes as values.
+        Each row in the dataframe is the identifier of a model within the resulting ensemble.
+        The dataframe has two columns, one for the lower and one for the upper bound of the reaction.
         As a reference, a valid boundsDict can be generated using the
         helper function _setBounds.
 
@@ -78,7 +78,7 @@ def boundsEnsemble(model, boundsDict):
 
     return ensemble
 
-def _setBoundsRandom(model, rxn_ids, bound=None, reversibility='respect', n_models=100):
+def _setBoundsRandom(model, rxn_ids, bound=None, reversibility=True, n_models=100):
     if bound is None:
         bound = 1000
         warnings.warn("No 'bound' provided for method 'random'. Defaulting to bound = 1000.")
@@ -96,7 +96,7 @@ def _setBoundsRandom(model, rxn_ids, bound=None, reversibility='respect', n_mode
         for rxn_id in rxn_ids
     }
 
-    if reversibility == 'respect':
+    if reversibility:
         for rxn_id in rxn_ids:
             if model.reactions.get_by_id(rxn_id).lower_bound == 0:
                 boundsDict[rxn_id].lower_bound = 0
@@ -123,16 +123,14 @@ def _setBoundsOnOff(model, rxn_ids):
     return boundsDict
 
 
-def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility='respect'):
+def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility=True):
     if bound is None:
         bound = 1000
         warnings.warn("No 'bound' provided for method 'fullFactorial'. Defaulting to bound = 1000.")
 
     default_options = [(-abs(bound), 0), (-abs(bound), abs(bound)), (0, 0), (0, abs(bound))]
 
-    if reversibility == 'ignore':    
-        bound_options_dict = {rxn_id: default_options for rxn_id in rxn_ids}
-    else:
+    if reversibility:
         bound_options_dict = {}
         for rxn_id in rxn_ids:
             if model.reactions.get_by_id(rxn_id).reversibility:
@@ -140,6 +138,8 @@ def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility='respect')
             else:
                 bound_options_dict[rxn_id] = [(0, 0), 
                                               tuple(bound * (x / abs(x)) if x != 0 else 0 for x in model.reactions.get_by_id(rxn_id).bounds)]
+    else:    
+        bound_options_dict = {rxn_id: default_options for rxn_id in rxn_ids}
 
     reaction_options = [bound_options_dict[rxn_id] for rxn_id in rxn_ids]
     all_combinations = list(itertools.product(*reaction_options))
@@ -156,7 +156,7 @@ def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility='respect')
 
     return boundsDict
 
-def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, n_models=100):
+def _setBounds(model, rxn_ids, method='random', reversibility=True, bound=None, n_models=100):
 
     ''' 
     Helper function for constructing object 'boundsDict', an argument used by 
@@ -191,12 +191,12 @@ def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, 
                 baseline model will be respected.
         Default is 'random'. 
 
-    reversibility : str, optional 
-        Options are 'respect' or 'ignore'. If 'respect', the reaction reversibility of the baseline
-        model will be respected. E.g., if the baseline model only allows for the forward reaction,
+    reversibility : boolean, optional 
+        If True, the reaction reversibility of the baseline model will be respected. 
+        E.g., if the baseline model only allows for the forward reaction,
         then reversibility or backward reactions will not be allowed for any of the new members.
-        If 'ignore', previously irreversible reactions will be allowed to be reversible.
-        Default is 'respect'.
+        If False, previously irreversible reactions will be allowed to be reversible.
+        Default is True.
 
     bound : float or int or None, optional 
         This value is used as the magnitude of the reaction bounds (e.g., ±bound). 
@@ -218,21 +218,14 @@ def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, 
     if method not in allowed_methods:
         raise ValueError(f"Invalid method '{method}'. Choose one of {allowed_methods}.")
 
-    allowed_reversibility = ['respect', 'ignore']
-    if reversibility is not None and reversibility not in allowed_reversibility:
-        raise ValueError(f"Invalid reversibility '{reversibility}'. Choose one of {allowed_reversibility}.")
-
     # Set defaults depending on method
     if method == 'random':
-        if reversibility is None:
-            reversibility = 'respect'
         boundsDict = _setBoundsRandom(model, rxn_ids, bound=bound, reversibility=reversibility, n_models=n_models)
 
     elif method == 'onOff':
         if bound is not None:
             warnings.warn("'bound' argument is ignored when method is 'onOff'")
-        if reversibility is not None:
-            warnings.warn("'reversibility' argument is ignored when method is 'onOff'")
+        warnings.warn("'reversibility' argument is ignored when method is 'onOff'")
         if n_models != 100:
             warnings.warn("'n_models' argument is ignored when method is 'onOff'")
         boundsDict = _setBoundsOnOff(model, rxn_ids)
@@ -243,9 +236,6 @@ def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, 
         if bound is None:
             bound = 1000
             warnings.warn("No 'bound' provided for method 'fullFactorial'. Defaulting to bound = 1000.")
-        if reversibility is None:
-            reversibility = 'respect'
-            warnings.warn("No 'reversibility' provided for method 'fullFactorial'. Defaulting to reversibility = 'respect'.")
         boundsDict = _setBoundsFullFactorial(model, rxn_ids, bound=bound, reversibility=reversibility)
 
     # Add row for base model at the top

--- a/medusa/boundsEnsemble.py
+++ b/medusa/boundsEnsemble.py
@@ -1,0 +1,202 @@
+from cobra.core import DictList
+from medusa.core.ensemble import Ensemble
+from medusa.core.member import Member
+from medusa.core.feature import Feature
+import warnings
+import numpy as np
+import pandas as pd
+import itertools
+
+REACTION_ATTRIBUTES = ['lower_bound', 'upper_bound']
+
+def boundsEnsemble(model, boundsDict):
+    '''
+    Create an ensemble of models where each member has the same reactions but
+    different reaction bounds, without the need of first constructing a list of these
+    individual models. While all members share the same reactions, the bounds of some
+    reactions in some members maybe set to (0,0), i.e., inactivating the reaction.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The ensemble with which to perform reaction deletions
+    boundsDict : A dictionary of pandas.DataFrames
+        A dictionary of dataframes in which each row (index) represents a 
+        model within the ensemble, and each column represents a reaction for 
+        which values of objective when the reaction is deleted are returned.
+
+    Returns
+    -------
+    Medusa.core.ensemble
+        An ensemble where each member has accordingly adjusted reaction bounds
+    '''
+
+    # Setup ensemble structure base on single baseline model
+    ensemble = Ensemble([model],
+                        identifier = "placeholderId",
+                        name = "placeholderName")
+    ensemble.features = DictList()
+    ensemble.members = DictList()
+
+    # Set features, similar to _populate_features_base()
+    for rxn_id in boundsDict.keys():
+        for attr in REACTION_ATTRIBUTES:
+            if boundsDict[rxn_id][attr].nunique() > 1:
+                rxn_base = ensemble.base_model.reactions.get_by_id(rxn_id)
+                feature_id = f"{rxn_id}_{attr}"
+
+                # Create states dict for feature
+                states = boundsDict[rxn_id][attr].to_dict()
+
+                # Create and add the Feature object
+                feature = Feature(
+                    ensemble=ensemble,
+                    identifier=feature_id,
+                    name=rxn_base.name,
+                    base_component=rxn_base,
+                    component_attribute=attr,
+                    states=states,
+                )
+                ensemble.features.append(feature)
+    
+    names = [ensemble.base_model.name] + ['placeholderName' for _ in range(len(boundsDict[next(iter(boundsDict))].index) - 1)]
+    ids = list(boundsDict[next(iter(boundsDict))].index)
+
+    # Populate members, similar to _populate_members()
+    for i in range(0,len(ids)):
+        model_states = dict()
+        for feature in ensemble.features:
+            model_states[feature] = feature.get_model_state(ids[i])
+        member = Member(ensemble=ensemble,\
+                        identifier=ids[i],\
+                        name=names[i],\
+                        states=model_states)
+
+        ensemble.members += [member]
+
+    return ensemble
+
+def _setBoundsRandom(model, rxn_ids, bound=None, reversibility='respect', n_models=100):
+    if bound is None:
+        bound = 1000
+        warnings.warn("No 'bound' provided for method 'random'. Defaulting to bound = 1000.")
+
+    if not isinstance(bound, (int, float)):
+        raise TypeError(f"'bound' must be a float or int, got {type(bound)}")
+
+    ids = [f'model_{i}' for i in range(n_models)]
+    
+    boundsDict = {
+        rxn_id: pd.DataFrame({
+            'lower_bound': np.random.uniform(-abs(bound), 0, size=len(ids)),
+            'upper_bound': np.random.uniform(0, abs(bound), size=len(ids))
+        }, index=ids)
+        for rxn_id in rxn_ids
+    }
+
+    if reversibility == 'respect':
+        for rxn_id in rxn_ids:
+            if model.reactions.get_by_id(rxn_id).lower_bound == 0:
+                boundsDict[rxn_id].lower_bound = 0
+            if model.reactions.get_by_id(rxn_id).upper_bound == 0:
+                boundsDict[rxn_id].upper_bound = 0
+
+    return boundsDict
+
+
+def _setBoundsOnOff(model, rxn_ids):
+
+    combinations = list(itertools.product([0,1], repeat=len(rxn_ids)))
+    df = pd.DataFrame(combinations, columns=rxn_ids)
+    df.index = [f"model_{i}" for i in range(len(df))]
+
+    boundsDict = {}
+    for rxn_id in df.columns:
+        values = df[rxn_id]
+        boundsDict[rxn_id] = pd.DataFrame({
+            'lower_bound': values * model.reactions.get_by_id(rxn_id).lower_bound + 0,
+            'upper_bound': values * model.reactions.get_by_id(rxn_id).upper_bound
+        }, index=df.index)
+
+    return boundsDict
+
+
+def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility='respect'):
+    if bound is None:
+        bound = 1000
+        warnings.warn("No 'bound' provided for method 'fullFactorial'. Defaulting to bound = 1000.")
+
+    default_options = [(-abs(bound), 0), (-abs(bound), abs(bound)), (0, 0), (0, abs(bound))]
+
+    if reversibility == 'ignore':    
+        bound_options_dict = {rxn_id: default_options for rxn_id in rxn_ids}
+    else:
+        bound_options_dict = {}
+        for rxn_id in rxn_ids:
+            if model.reactions.get_by_id(rxn_id).reversibility:
+                bound_options_dict[rxn_id] = default_options
+            else:
+                bound_options_dict[rxn_id] = [(0, 0), 
+                                              tuple(bound * (x / abs(x)) if x != 0 else 0 for x in model.reactions.get_by_id(rxn_id).bounds)]
+
+    reaction_options = [bound_options_dict[rxn_id] for rxn_id in rxn_ids]
+    all_combinations = list(itertools.product(*reaction_options))
+    row_labels = [f"model_{i}" for i in range(len(all_combinations))]
+    
+    boundsDict = {}
+    for i, rxn_id in enumerate(rxn_ids):
+        lower_bounds = [combo[i][0] for combo in all_combinations]
+        upper_bounds = [combo[i][1] for combo in all_combinations]
+        boundsDict[rxn_id] = pd.DataFrame({
+            'lower_bound': lower_bounds,
+            'upper_bound': upper_bounds
+        }, index=row_labels)
+
+    return boundsDict
+
+def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, n_models=100):
+    allowed_methods = ['random', 'onOff', 'fullFactorial']
+    if method not in allowed_methods:
+        raise ValueError(f"Invalid method '{method}'. Choose one of {allowed_methods}.")
+
+    allowed_reversibility = ['respect', 'ignore']
+    if reversibility is not None and reversibility not in allowed_reversibility:
+        raise ValueError(f"Invalid reversibility '{reversibility}'. Choose one of {allowed_reversibility}.")
+
+    # Set defaults depending on method
+    if method == 'random':
+        if reversibility is None:
+            reversibility = 'respect'
+        boundsDict = _setBoundsRandom(model, rxn_ids, bound=bound, reversibility=reversibility, n_models=n_models)
+
+    elif method == 'onOff':
+        if bound is not None:
+            warnings.warn("'bound' argument is ignored when method is 'onOff'")
+        if reversibility is not None:
+            warnings.warn("'reversibility' argument is ignored when method is 'onOff'")
+        if n_models != 100:
+            warnings.warn("'n_models' argument is ignored when method is 'onOff'")
+        boundsDict = _setBoundsOnOff(model, rxn_ids)
+
+    elif method == 'fullFactorial':
+        if n_models != 100:
+            warnings.warn("'n_models' argument is ignored when method is 'fullFactorial'")
+        if bound is None:
+            bound = 1000
+            warnings.warn("No 'bound' provided for method 'fullFactorial'. Defaulting to bound = 1000.")
+        if reversibility is None:
+            reversibility = 'respect'
+            warnings.warn("No 'reversibility' provided for method 'fullFactorial'. Defaulting to reversibility = 'respect'.")
+        boundsDict = _setBoundsFullFactorial(model, rxn_ids, bound=bound, reversibility=reversibility)
+
+    # Add row for base model at the top
+    for rxn_id in rxn_ids:
+        boundsDict[rxn_id] = pd.concat([
+            pd.DataFrame({
+                'lower_bound': [model.reactions.get_by_id(rxn_id).lower_bound],
+                'upper_bound': [model.reactions.get_by_id(rxn_id).upper_bound]
+            }, index=[model.id]),
+            boundsDict[rxn_id]
+        ])
+
+    return boundsDict

--- a/medusa/boundsEnsemble.py
+++ b/medusa/boundsEnsemble.py
@@ -24,6 +24,8 @@ def boundsEnsemble(model, boundsDict):
         A dictionary of dataframes in which each row (index) represents a 
         model within the ensemble, and each column represents a reaction for 
         which values of objective when the reaction is deleted are returned.
+        As a reference, a valid boundsDict can be generated using the
+        helper function _setBounds.
 
     Returns
     -------
@@ -155,6 +157,63 @@ def _setBoundsFullFactorial(model, rxn_ids, bound=None, reversibility='respect')
     return boundsDict
 
 def _setBounds(model, rxn_ids, method='random', reversibility=None, bound=None, n_models=100):
+
+    ''' 
+    Helper function for constructing object 'boundsDict', an argument used by 
+    the 'boundsEnsemble' function. Users can provide their own boundsDict, this 
+    helper function exists only for providing users with reusable code and for 
+    internal function testing. 
+
+    Parameters
+    ----------
+    model : cobra.Model A single cobraPy Model that will be used as a baseline
+        to generate an ensemble of models with different reaction bounds for a select
+        set of reactions.
+    
+    rxn_ids : list of str 
+        Target reactions for which each ensemble member will have a different 
+        combination of bounds.
+
+    method : str, optional 
+        Method used to generate reaction bounds.
+        Must be one of: 
+            - 'random' : The value of the lower and upper bound of each target reaction 
+                is chosen as a random integer between 0 and the bound provided in 
+                the 'bound' argument.
+            - 'onOff' : Sets reactions to either completely off (0, 0) or active (-bound, +bound). 
+                The number of models that will be created is two to the power of the number of
+                target reactions (length of rxn_ids argument).
+            - 'fullFactorial' : Creates all possible combinations of states for all target reactions.
+                I.e., each reaction can take on values (0,0), (-bound,0), (0,bound), and (-bound, bound).
+                The number of potential combinations is thus four to the power of the number of
+                target reactions (length of rxn_ids argument). Note, that if reversibility is 'respect',
+                some options will be removed, i.e., the reversibility direction of the reaction in the
+                baseline model will be respected.
+        Default is 'random'. 
+
+    reversibility : str, optional 
+        Options are 'respect' or 'ignore'. If 'respect', the reaction reversibility of the baseline
+        model will be respected. E.g., if the baseline model only allows for the forward reaction,
+        then reversibility or backward reactions will not be allowed for any of the new members.
+        If 'ignore', previously irreversible reactions will be allowed to be reversible.
+        Default is 'respect'.
+
+    bound : float or int or None, optional 
+        This value is used as the magnitude of the reaction bounds (e.g., ±bound). 
+        If None (default), a bound of 1000 is used internally.
+
+    n_models : int
+        Number of models that will be created if method is 'random', ignored otherwise.
+        Default is 100.
+
+    Returns
+    -------
+    boundsDict : A dictionary of pandas.DataFrames A dictionary of dataframes in which
+        each row (index) represents a model within the ensemble, and each column represents
+        a reaction for which values of objective when the reaction is deleted are returned.
+
+    '''
+
     allowed_methods = ['random', 'onOff', 'fullFactorial']
     if method not in allowed_methods:
         raise ValueError(f"Invalid method '{method}'. Choose one of {allowed_methods}.")

--- a/medusa/core/ensemble.py
+++ b/medusa/core/ensemble.py
@@ -72,7 +72,7 @@ class Ensemble(Object):
                     raise AttributeError("list_of_models may only contain cobra.core.Model objects")
                 self.base_model = list_of_models[0]
 
-    def _populate_features_base_new(self, list_of_models):
+    def _populate_features_base(self, list_of_models):
         # Determine all reactions across all models and construct the base model
         base_model = list_of_models[0].copy()
         all_reactions = set(rxn.id for rxn in base_model.reactions)
@@ -114,7 +114,7 @@ class Ensemble(Object):
             rxn_vals = pd.DataFrame.from_dict(rxn_vals, orient='index') # TODO remark: faster than transposing
 
             for reaction_attribute in REACTION_ATTRIBUTES:
-                if rxn_vals[reaction_attribute].nunique() > 1:
+                if rxn_vals[reaction_attribute].nunique() > 1: # TODO remark: used to be len() > 1, seems incorrect
                     rxn_from_base = base_model.reactions.get_by_id(reaction)
                     feature_id = f"{reaction}_{reaction_attribute}"
                     feature_id = rxn_from_base.id + '_' + reaction_attribute

--- a/medusa/core/ensemble.py
+++ b/medusa/core/ensemble.py
@@ -72,52 +72,66 @@ class Ensemble(Object):
                     raise AttributeError("list_of_models may only contain cobra.core.Model objects")
                 self.base_model = list_of_models[0]
 
-    def _populate_features_base(self,list_of_models):
+    def _populate_features_base_new(self, list_of_models):
         # Determine all reactions across all models and construct the base model
-        all_reactions = set()
         base_model = list_of_models[0].copy()
-        all_reactions = all_reactions | set([rxn.id for rxn in base_model.reactions])
+        all_reactions = set(rxn.id for rxn in base_model.reactions)
         for model in list_of_models:
-            new_reactions = set([rxn.id for rxn in model.reactions]) - \
-                                all_reactions
-            reactions_to_add = [model.reactions.get_by_id(rxn) for rxn in new_reactions]
-            base_model.add_reactions(reactions_to_add)
-            all_reactions = all_reactions | set([rxn.id for rxn in model.reactions])
-
+            model_rxn_ids = set(rxn.id for rxn in model.reactions)
+            new_reactions = model_rxn_ids - all_reactions
+            if new_reactions:
+                reactions_to_add = [model.reactions.get_by_id(rxn_id) for rxn_id in new_reactions]
+                base_model.add_reactions(reactions_to_add)
+                all_reactions.update(new_reactions)
         all_reactions = list(all_reactions)
 
-        # Determine reactions that vary in any model and construct a feature for
-        # each unique parameter value for that reaction in the ensemble
-        variable_reactions = []
+        # Pre-cache model reaction attributes in dicts to avoid repeated getattr calls
+        model_reaction_attrs = {}
+        for model in list_of_models:
+            mid = model.id
+            model_reaction_attrs[mid] = {}
+            for rxn in model.reactions:
+                # Direct attribute access instead of getattr
+                model_reaction_attrs[mid][rxn.id] = {
+                    'lower_bound': rxn.lower_bound,
+                    'upper_bound': rxn.upper_bound
+                }
+
+        # Iterate over each reaction to detect variable attributes
         for reaction in all_reactions:
+            # Collect reaction attributes per model
             rxn_vals = {}
             for model in list_of_models:
-                rxn_vals[model.id] = {}
-                if reaction in [x.id for x in model.reactions]:
-                    rxn = model.reactions.get_by_id(reaction)
-                    for reaction_attribute in REACTION_ATTRIBUTES:
-                        rxn_vals[model.id][reaction_attribute] = \
-                            getattr(rxn,reaction_attribute)
-                else: # for reactions not present in this model, select the default
-                    for reaction_attribute in REACTION_ATTRIBUTES:
-                        rxn_vals[model.id][reaction_attribute] = \
-                            MISSING_ATTRIBUTE_DEFAULT[reaction_attribute]
+                mid = model.id
+                rxn_attrs = model_reaction_attrs[mid]
+                if reaction in rxn_attrs:
+                    rxn_vals[mid] = rxn_attrs[reaction]
+                else:
+                    # Use default bounds if reaction missing from model
+                    rxn_vals[mid] = {'lower_bound': 0, 'upper_bound': 0} # TODO remark: could use MISSING_ATTRIBUTE_DEFAULT instead
 
-            rxn_vals = pd.DataFrame(rxn_vals).T
+            # Create a DataFrame for easier analysis of attribute variability
+            rxn_vals = pd.DataFrame.from_dict(rxn_vals, orient='index') # TODO remark: faster than transposing
+
             for reaction_attribute in REACTION_ATTRIBUTES:
-                if len(rxn_vals[reaction_attribute].unique()) > 1:
+                if rxn_vals[reaction_attribute].nunique() > 1:
                     rxn_from_base = base_model.reactions.get_by_id(reaction)
+                    feature_id = f"{reaction}_{reaction_attribute}"
                     feature_id = rxn_from_base.id + '_' + reaction_attribute
+
+                    # Create states dict for feature
                     states = rxn_vals[reaction_attribute].to_dict()
-                    #states = {model.id:rxn_vals[model.id][reaction_attribute] for model in list_of_models}
-                    feature = Feature(ensemble=self,\
-                                        identifier=feature_id,\
-                                        name=rxn_from_base.name,\
-                                        base_component=rxn_from_base,\
-                                        component_attribute=reaction_attribute,\
-                                        states=states)
-                    self.features += [feature]
-                    variable_reactions.append(reaction)
+
+                    # Create and add the Feature object
+                    feature = Feature(
+                        ensemble=self,
+                        identifier=feature_id,
+                        name=rxn_from_base.name,
+                        base_component=rxn_from_base,
+                        component_attribute=reaction_attribute,
+                        states=states,
+                    )
+                    self.features.append(feature)
 
         self.base_model = base_model
 

--- a/medusa/flux_analysis/flux_balance.py
+++ b/medusa/flux_analysis/flux_balance.py
@@ -12,11 +12,14 @@ from cobra import Reaction
 
 from medusa.core.member import Member
 
-
 def _optimize_ensemble(ensemble, return_flux, member_id, **kwargs):
+
     ensemble.set_state(member_id)
     ensemble.base_model.optimize(**kwargs)
-    flux_dict = {rxn:ensemble.base_model.reactions.get_by_id(rxn).flux
+
+    # TODO solved the error, but revise!
+    reaction_ids = [rxn.id for rxn in ensemble.base_model.reactions]
+    flux_dict = {rxn:ensemble.base_model.reactions[reaction_ids.index(rxn)].flux
                         for rxn in return_flux}
     return (member_id, flux_dict, ensemble.base_model.solver.status)
 

--- a/medusa/flux_analysis/variability.py
+++ b/medusa/flux_analysis/variability.py
@@ -1,4 +1,4 @@
-from pandas import DataFrame
+import pandas as pd
 from random import sample
 from cobra.flux_analysis.variability import (
     flux_variability_analysis, find_blocked_reactions,
@@ -60,7 +60,7 @@ def ensemble_fva(ensemble, reaction_list, num_models=[],specific_models=None,
 
     # initialize dataframe to store results. max and min for each model will
     # each take a single row, and the columns will be reactions.
-    all_fva_results = DataFrame()
+    all_fva_results = pd.DataFrame()
 
     if specific_models:
         model_list = specific_models
@@ -79,5 +79,5 @@ def ensemble_fva(ensemble, reaction_list, num_models=[],specific_models=None,
             fva_result = fva_result.T
             # add the model source as a column
             fva_result['model_source'] = [model,model]
-            all_fva_results = all_fva_results.append(fva_result)
+            all_fva_results = pd.concat([all_fva_results, fva_result])
     return all_fva_results

--- a/medusa/reconstruct/load_from_file.py
+++ b/medusa/reconstruct/load_from_file.py
@@ -1,6 +1,6 @@
 import medusa
 import cobra
-import cobra.test
+import cobra.io
 import math
 import copy
 import random

--- a/medusa/test/__init__.py
+++ b/medusa/test/__init__.py
@@ -4,7 +4,7 @@ import cobra
 import json
 import pandas as pd
 
-import cobra.test
+import cobra.io
 from cobra.core import Reaction
 
 from medusa.core.ensemble import Ensemble
@@ -33,14 +33,14 @@ def create_test_ensemble(ensemble_name="Staphylococcus aureus"):
 def create_test_model(model_name="textbook"):
     """Returns a cobra.Model for testing
     model_name: str
-        One of ['Staphylococcus aureus'] or any models in cobra.test
+        One of ['Staphylococcus aureus'] or any models in cobra.io
     """
     if model_name == "Saureus_seed":
         base_model = cobra.io.load_json_model(join(data_dir, 'Staphylococcus aureus.json'))
 
     else:
         try:
-            base_model = cobra.test.create_test_model(model_name)
+            base_model = cobra.io.load_model(model_name)
         except:
             raise ValueError('model_name does not match one of the test models available')
 

--- a/medusa/test/test_boundsEnsemble.py
+++ b/medusa/test/test_boundsEnsemble.py
@@ -1,0 +1,43 @@
+from cobra.core.model import Model
+from cobra.io import load_model
+from medusa.core.ensemble import Ensemble
+
+# TODO update later if boundsEnsemble gets moved
+from medusa.boundsEnsemble import boundsEnsemble
+from medusa.boundsEnsemble import _setBounds
+
+import pytest
+
+def test_boundsEnsemble():
+
+    textbook = load_model("textbook")
+
+    # based on the textbook model, generate an ensemble in which the members
+    # only differ w.r.t. their bounds for specified reactions
+    boundsDict = _setBounds(textbook, 
+                            [rxn.id for rxn in textbook.reactions[0:5]], 
+                            method='random', 
+                            reversibility=None, 
+                            bound=1000, 
+                            n_models=10)
+    test_ensemble = boundsEnsemble(textbook, boundsDict)
+
+    assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
+    assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
+
+    # the ensemble should have 1 feature and 11 members
+    assert len(test_ensemble.features) == 10
+    assert len(test_ensemble.members) == 11
+
+    # each member in the ensemble should have 10 features and values in their states
+    # each member should have a reference to the correct ensemble object
+    for member in test_ensemble.members:
+        assert len(member.states) == 10
+        assert member.ensemble == test_ensemble
+
+    # each feature should reference a reaction contained in the original model
+    assert [feature.base_component in test_ensemble.base_model.reactions for feature in test_ensemble.features]
+
+    # it should be possible to extract an individual member
+    model_from_id = test_ensemble.extract_member('model_0')
+    assert type(model_from_id) is Model

--- a/medusa/test/test_ensemble.py
+++ b/medusa/test/test_ensemble.py
@@ -1,4 +1,4 @@
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 
 from pickle import load
@@ -10,10 +10,10 @@ MISSING_ATTRIBUTE_DEFAULT = {'lower_bound':0,'upper_bound':0}
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2],
@@ -22,13 +22,13 @@ def construct_textbook_ensemble():
 
 def construct_mixed_ensemble():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model4 = model3.copy()
@@ -43,7 +43,7 @@ def test_ensemble_creation():
     test_ensemble = construct_textbook_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 
@@ -72,7 +72,7 @@ def test_mixed_ensemble_creation():
     test_ensemble = construct_mixed_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 
@@ -97,7 +97,7 @@ def test_mixed_ensemble_creation():
 
 def test_extract_member():
     test_ensemble = construct_textbook_ensemble()
-    original_model = create_test_model("textbook")
+    original_model = load_model("textbook")
 
     extracted_member = test_ensemble.extract_member(test_ensemble.members[0])
 
@@ -145,7 +145,7 @@ def test_pickle():
         unpickled = load(infile)
 
     test_ensemble = unpickled
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
 

--- a/medusa/test/test_ensemble.py
+++ b/medusa/test/test_ensemble.py
@@ -163,7 +163,8 @@ def test_pickle():
     # each feature should have a component_attribute in the list of allowable
     # attributes
     # each feature should have at least two unique state values across all models
+    reaction_ids = {rxn.id for rxn in test_ensemble.base_model.reactions}
     for feature in test_ensemble.features:
-        assert feature.base_component in test_ensemble.base_model.reactions
+        assert feature.base_component.id in reaction_ids
         assert feature.component_attribute in REACTION_ATTRIBUTES
         assert len(set(feature.states.values())) > 1

--- a/medusa/test/test_flux_balance.py
+++ b/medusa/test/test_flux_balance.py
@@ -86,5 +86,5 @@ def test_fba_specific_models():
         assert rows == len(model_list)
         assert columns == len(ensemble.base_model.reactions)
 
-        assert rownames.contains(model1.id)
-        assert rownames.contains(model2.id)
+        assert model1.id in rownames
+        assert model2.id in rownames

--- a/medusa/test/test_flux_balance.py
+++ b/medusa/test/test_flux_balance.py
@@ -1,15 +1,15 @@
 
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.flux_analysis.flux_balance import optimize_ensemble
 
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2],
@@ -18,13 +18,13 @@ def construct_textbook_ensemble():
 
 def construct_mixed_ensemble():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model4 = model3.copy()

--- a/medusa/test/test_load_from_file.py
+++ b/medusa/test/test_load_from_file.py
@@ -1,5 +1,5 @@
 import cobra
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.reconstruct.load_from_file import batch_load_from_files
 
@@ -8,15 +8,15 @@ MISSING_ATTRIBUTE_DEFAULT = {'lower_bound':0,'upper_bound':0}
 
 def construct_mixed_ensemble_2():
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
     cobra.io.save_json_model(model1, "model1.json")
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     cobra.io.save_json_model(model2, "model2.json")
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model3.reactions.get_by_id('SUCCt2_2').lower_bound = -1000
@@ -34,15 +34,15 @@ def construct_mixed_batch_ensemble():
     # UPDATE PATHS TO SAVE AND LOAD MODELS
     
     # create 4 models, which have reactions removed and a bound difference.
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
     cobra.io.save_json_model(model1, "model1.json")
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
     cobra.io.save_json_model(model2, "model2.json")
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[5:7])
     model3.id = 'third_textbook'
     model3.reactions.get_by_id('SUCCt2_2').lower_bound = -1000
@@ -63,7 +63,7 @@ def test_batch_load_vs_innate():
     test_batch_ensemble = construct_mixed_batch_ensemble()
     # The base model should have the same number of reactions and metabolites
     # as the original model, since we only remove/modify reactions.
-    textbook = create_test_model("textbook")
+    textbook = load_model("textbook")
     assert len(test_ensemble.base_model.reactions) == len(textbook.reactions)
     assert len(test_ensemble.base_model.metabolites) == len(textbook.metabolites)
     assert len(test_batch_ensemble.base_model.reactions) == len(textbook.reactions)

--- a/medusa/test/test_reconstruct.py
+++ b/medusa/test/test_reconstruct.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from cobra.test import create_test_model
+from cobra.io import load_model
 from cobra.io import load_json_model
 from cobra.core import Reaction
 

--- a/medusa/test/test_variability.py
+++ b/medusa/test/test_variability.py
@@ -1,17 +1,17 @@
-from cobra.test import create_test_model
+from cobra.io import load_model
 from medusa.core.ensemble import Ensemble
 from medusa.flux_analysis.variability import ensemble_fva
 
 
 def construct_textbook_ensemble():
     # create two identical models and make an ensemble
-    model1 = create_test_model("textbook")
+    model1 = load_model("textbook")
     model1.remove_reactions(model1.reactions[1:3])
     model1.id = 'first_textbook'
-    model2 = create_test_model("textbook")
+    model2 = load_model("textbook")
     model2.remove_reactions(model2.reactions[4:6])
     model2.id = 'second_textbook'
-    model3 = create_test_model("textbook")
+    model3 = load_model("textbook")
     model3.remove_reactions(model3.reactions[2:5])
     model3.id = 'third_textbook'
     textbook_ensemble = Ensemble(list_of_models=[model1,model2,model3],


### PR DESCRIPTION
One aspect hampering the use of Medusa for certain applications is the need to construct a list of GEMs prior to creating and analyzing the ensemble. Indeed, in many situations, it is computationally less expensive to create and analyze each member of the fly. This feature allows for directly populating the ensemble without needing to first generate each individual member, for one specific situation. This feature allows for directly populating an ensemble where members only differ w.r.t. the lower and/or upper bounds for certain reactions. Note that as bounds can be set to zero, reaction reversibility and presence is allowed to be affected. Changes made:

- boundsEnsemble.py: workhorse
- test_boundsEnsemble.py: test validity
- **TODO:** Note that this branch also includes changes made in the `maintenance` and `refactor_populate_features_base` branches, I can undo this if this is inconvenient


Happy to discuss if functions like these would be a good fit for Medusa, or if they should be ported elsewhere.